### PR TITLE
Add Nix support

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "url": "https://github.com/FancyStudioTeam/OceanicBuilders"
   },
   "scripts": {
-    "biome": "biome check --write --config-path biome.json",
+    "biome": "sh -c 'if [ \"$IN_NIX_SHELL\" = \"1\" ]; then BIOME_BINARY=$BIOME_BIN_PATH pnpx @biomejs/biome check --write --config-path biome.json; else pnpx @biomejs/biome check --write --config-path biome.json; fi'",
     "build": "tsc",
     "docs:build": "pnpm --filter docs build",
     "docs:dev": "pnpm --filter docs dev",

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,16 @@
+{pkgs ? import <nixpkgs> {}}:
+pkgs.mkShell {
+  buildInputs = [
+    pkgs.nodejs_20
+    pkgs.pnpm
+    pkgs.biome
+  ];
+
+  # Optionally, you can set shell hooks to run scripts when entering the shell
+  shellHook = ''
+    export NODE_ENV=development
+    export IN_NIX_SHELL=1
+    export BIOME_BIN_PATH=$(which biome)
+    echo "Welcome! NodeJS: $(node -v) - PNPM: $(pnpm -v) - Biome: $(biome --version)"
+  '';
+}


### PR DESCRIPTION
Added shell.nix so that Node, PNPM and Biome get made available to Nix users upon running `nix-shell`. Biome works.